### PR TITLE
[FEAT] 본인 인증 ( #18 )

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
 	// Google Maps Services (Geocoding/Places API)
 	implementation "com.google.maps:google-maps-services:2.2.0"
+
+    // SMS
+    implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/somsomcore/zipcheck/domain/auth/controller/AuthController.java
+++ b/src/main/java/somsomcore/zipcheck/domain/auth/controller/AuthController.java
@@ -4,11 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import somsomcore.zipcheck.domain.auth.dto.AuthResponseDto;
-import somsomcore.zipcheck.domain.auth.dto.SocialLoginRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.TestTokenRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.TokenRefreshRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.TokenRefreshResponseDto;
+import somsomcore.zipcheck.domain.auth.dto.*;
 import somsomcore.zipcheck.domain.auth.service.AuthService;
 import somsomcore.zipcheck.global.apiPayload.ApiResponse;
 import somsomcore.zipcheck.global.security.CustomUserDetails;
@@ -48,4 +44,20 @@ public class AuthController {
         AuthResponseDto response = authService.generateTestToken(request);
         return ApiResponse.onSuccess(response);
     }
+
+	@Operation(summary = "본인 인증 문자 메시지 발송", description = "본인 인증을 위한 문자 메시지를 발송합니다.")
+	@PostMapping("/verification-code")
+	public ApiResponse<String> sendValidationMessage(@Valid @RequestBody ValidationMessageRequestDto request,
+													 @AuthenticationPrincipal CustomUserDetails userDetails) {
+		authService.sendValidationMessage(userDetails.getUser().getId(), request);
+		return ApiResponse.onSuccess("성공적으로 메시지를 전송했습니다.");
+	}
+
+	@Operation(summary = "본인 인증 코드 검증", description = "사용자가 입력한 본인 인증 코드를 검증합니다.")
+	@PostMapping("/verification")
+	public ApiResponse<String> validateUserPhone(@Valid @RequestBody ValidatePhoneRequestDto request,
+												 @AuthenticationPrincipal CustomUserDetails userDetails) {
+		authService.validateUserPhone(userDetails.getUser().getId(), request);
+		return ApiResponse.onSuccess("성공적으로 인증되었습니다.");
+	}
 }

--- a/src/main/java/somsomcore/zipcheck/domain/auth/dto/ValidatePhoneRequestDto.java
+++ b/src/main/java/somsomcore/zipcheck/domain/auth/dto/ValidatePhoneRequestDto.java
@@ -1,0 +1,13 @@
+package somsomcore.zipcheck.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ValidatePhoneRequestDto {
+	
+	@NotBlank(message = "인증 번호는 필수입니다.")
+	private String verificationCode;
+}

--- a/src/main/java/somsomcore/zipcheck/domain/auth/dto/ValidationMessageRequestDto.java
+++ b/src/main/java/somsomcore/zipcheck/domain/auth/dto/ValidationMessageRequestDto.java
@@ -1,0 +1,13 @@
+package somsomcore.zipcheck.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ValidationMessageRequestDto {
+	
+	@NotBlank(message = "전화번호는 필수입니다.")
+	private String phone;
+}

--- a/src/main/java/somsomcore/zipcheck/domain/auth/service/AuthService.java
+++ b/src/main/java/somsomcore/zipcheck/domain/auth/service/AuthService.java
@@ -4,12 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import somsomcore.zipcheck.domain.auth.dto.AuthResponseDto;
-import somsomcore.zipcheck.domain.auth.dto.SocialLoginRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.SocialUserInfoDto;
-import somsomcore.zipcheck.domain.auth.dto.TestTokenRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.TokenRefreshRequestDto;
-import somsomcore.zipcheck.domain.auth.dto.TokenRefreshResponseDto;
+import somsomcore.zipcheck.domain.auth.dto.*;
 import somsomcore.zipcheck.domain.auth.entity.RefreshToken;
 import somsomcore.zipcheck.domain.auth.repository.RefreshTokenRepository;
 import somsomcore.zipcheck.domain.user.entity.User;
@@ -18,6 +13,8 @@ import somsomcore.zipcheck.domain.user.repository.UserRepository;
 import somsomcore.zipcheck.global.apiPayload.code.status.ErrorStatus;
 import somsomcore.zipcheck.global.apiPayload.exception.GeneralException;
 import somsomcore.zipcheck.global.jwt.JwtUtil;
+import somsomcore.zipcheck.global.util.SmsUtil;
+import somsomcore.zipcheck.global.util.ValidationUtil;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -32,6 +29,8 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
+	private final ValidationUtil validationUtil;
+	private final SmsUtil smsUtil;
 
     public AuthResponseDto socialLogin(SocialLoginRequestDto request) {
         SocialUserInfoDto socialUserInfo = oAuthService.getSocialUserInfo(request.getAccessToken(), request.getProvider());
@@ -69,7 +68,7 @@ public class AuthService {
                 .oauthType(socialUserInfo.getProvider())
                 .role(Role.MEMBER)
                 .phone("")
-                .isVerified(true)
+                .isVerified(false)
                 .build();
 
         User savedUser = userRepository.save(newUser);
@@ -147,4 +146,40 @@ public class AuthService {
                         .build())
                 .build();
     }
+	
+	public void sendValidationMessage(Long userId, ValidationMessageRequestDto request) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+		
+		if (!request.getPhone().matches("^010(-\\d{4}-\\d{4}|\\d{8})$")) {
+			throw new GeneralException(ErrorStatus.INVALID_PHONE_NUMBER);
+		}
+		
+		String verificationCode = validationUtil.createCode();
+		user.updatePhoneValidation(verificationCode, LocalDateTime.now().plusMinutes(10));
+		userRepository.save(user);
+		
+		smsUtil.sendOne(request.getPhone(), verificationCode);
+	}
+	
+	public void validateUserPhone(Long userId, ValidatePhoneRequestDto request) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+		String userVerificationCode = user.getPhoneValidationCode();
+		
+		if (userVerificationCode == null || userVerificationCode.isEmpty()) {
+			throw new GeneralException(ErrorStatus.VERIFICATION_NOT_FOUND);
+		}
+		if(user.getPhoneValidationExpiresAt().isBefore(LocalDateTime.now())) {
+			throw new GeneralException(ErrorStatus.VERIFICATION_EXPIRED);
+		}
+		if(!userVerificationCode.equals(request.getVerificationCode())) {
+			throw new GeneralException(ErrorStatus.VERIFICATION_INVALID);
+		}
+		
+		user.setVerified(true);
+		user.setPhoneValidationCode(null);
+		user.setPhoneValidationExpiresAt(null);
+		userRepository.save(user);
+	}
 }

--- a/src/main/java/somsomcore/zipcheck/domain/auth/service/AuthService.java
+++ b/src/main/java/somsomcore/zipcheck/domain/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import somsomcore.zipcheck.global.apiPayload.exception.GeneralException;
 import somsomcore.zipcheck.global.jwt.JwtUtil;
 import somsomcore.zipcheck.global.util.SmsUtil;
 import somsomcore.zipcheck.global.util.ValidationUtil;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -24,6 +25,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
+
+    @Value("${zipcheck.verification.code-expiry-minutes}")
+    private long codeExpiryMinutes;
 
     private final OAuthService oAuthService;
     private final UserRepository userRepository;
@@ -156,7 +160,7 @@ public class AuthService {
 		}
 		
 		String verificationCode = validationUtil.createCode();
-		user.updatePhoneValidation(verificationCode, LocalDateTime.now().plusMinutes(10));
+		user.updatePhoneValidation(verificationCode, LocalDateTime.now().plusMinutes(codeExpiryMinutes));
 		userRepository.save(user);
 		
 		smsUtil.sendOne(request.getPhone(), verificationCode);

--- a/src/main/java/somsomcore/zipcheck/domain/user/entity/User.java
+++ b/src/main/java/somsomcore/zipcheck/domain/user/entity/User.java
@@ -6,6 +6,8 @@ import somsomcore.zipcheck.domain.user.entity.enums.OauthType;
 import somsomcore.zipcheck.domain.user.entity.enums.Role;
 import somsomcore.zipcheck.global.common.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 @Setter
@@ -40,6 +42,14 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String phone;
 
+	// 전화번호 인증 코드 (추후 Redis 교체 예정)
+	@Column
+	private String phoneValidationCode;
+	
+	// 전화번호 인증 만료 일자
+	@Column
+	private LocalDateTime phoneValidationExpiresAt;
+
     // 전화번호 인증 여부
     @Column(nullable = false)
     private boolean isVerified;
@@ -48,5 +58,8 @@ public class User extends BaseEntity {
     @Column
     private String profileUrl;
 
-
+	public void updatePhoneValidation(String code, LocalDateTime expiresAt) {
+		this.phoneValidationCode = code;
+		this.phoneValidationExpiresAt = expiresAt;
+	}
 }

--- a/src/main/java/somsomcore/zipcheck/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/somsomcore/zipcheck/global/apiPayload/code/status/ErrorStatus.java
@@ -29,8 +29,14 @@ public enum ErrorStatus implements BaseErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4005", "리프레시 토큰을 찾을 수 없습니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4006", "만료된 리프레시 토큰입니다."),
     OAUTH_USER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH4007", "소셜 사용자 정보 조회에 실패했습니다."),
-
-    // 주소
+	
+	// 전화번호 인증
+	INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "AUTH4008", "유효하지 않은 전화번호 형식입니다."),
+	VERIFICATION_INVALID(HttpStatus.BAD_REQUEST, "AUTH4009", "유효하지 않은 인증 번호입니다."),
+	VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4010", "인증 번호가 만료되었습니다."),
+	VERIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4011", "인증 번호를 찾을 수 없습니다."),
+	
+	// 주소
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS4000", "입력하신 주소를 찾을 수 없습니다. 도로명/지번과 상세주소를 다시 확인해 주세요."),
     GEOCODING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ADDRESS4001", "주소 좌표를 조회하는 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요."),
 
@@ -54,7 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     FILE_INVALID_PATH(HttpStatus.BAD_REQUEST, "FILE4003", "허용되지 않은 경로입니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "파일 업로드에 실패했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5002", "파일 삭제에 실패했습니다.");
-    
+	
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/somsomcore/zipcheck/global/util/SmsUtil.java
+++ b/src/main/java/somsomcore/zipcheck/global/util/SmsUtil.java
@@ -1,0 +1,36 @@
+package somsomcore.zipcheck.global.util;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmsUtil {
+	
+	@Value("${SOLAPI_API_KEY}")
+	private String apiKey;
+	
+	@Value("${SOLAPI_API_SECRET}")
+	private String apiSecret;
+	
+	private DefaultMessageService messageService;
+	
+	@PostConstruct
+	public void init() {
+		this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+	}
+	
+	public SingleMessageSentResponse sendOne(String to, String verificationCode) {
+		Message message = new Message();
+		message.setFrom("01020702282");
+		message.setTo(to);
+		message.setText("[Zipcheck] 아래의 인증번호를 입력해주세요\n" + verificationCode);
+		
+		return this.messageService.sendOne(new SingleMessageSendingRequest(message));
+	}
+}

--- a/src/main/java/somsomcore/zipcheck/global/util/SmsUtil.java
+++ b/src/main/java/somsomcore/zipcheck/global/util/SmsUtil.java
@@ -11,26 +11,32 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SmsUtil {
-	
+
 	@Value("${SOLAPI_API_KEY}")
 	private String apiKey;
-	
+
 	@Value("${SOLAPI_API_SECRET}")
 	private String apiSecret;
-	
+
+	@Value("${solapi.domain}")
+	private String domain;
+
+	@Value("${solapi.from-number}")
+	private String fromNumber;
+
 	private DefaultMessageService messageService;
-	
+
 	@PostConstruct
 	public void init() {
-		this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+		this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, domain);
 	}
-	
+
 	public SingleMessageSentResponse sendOne(String to, String verificationCode) {
 		Message message = new Message();
-		message.setFrom("01020702282");
+		message.setFrom(fromNumber);
 		message.setTo(to);
 		message.setText("[Zipcheck] 아래의 인증번호를 입력해주세요\n" + verificationCode);
-		
+
 		return this.messageService.sendOne(new SingleMessageSendingRequest(message));
 	}
 }

--- a/src/main/java/somsomcore/zipcheck/global/util/ValidationUtil.java
+++ b/src/main/java/somsomcore/zipcheck/global/util/ValidationUtil.java
@@ -1,0 +1,16 @@
+package somsomcore.zipcheck.global.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ValidationUtil {
+	
+	public String createCode() {
+		StringBuilder code = new StringBuilder();
+		for (int i = 0; i < 6; i++) {
+			int digit = (int) (Math.random() * 10);
+			code.append(digit);
+		}
+		return code.toString();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,11 @@ jwt:
 google:
   api:
     key: ${GOOGLE_API_KEY}
+
+solapi:
+  from-number: "01020702282"
+  domain: "https://api.solapi.com"
+
+zipcheck:
+  verification:
+    code-expiry-minutes: 10


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #18 


## 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


## 📝작업 내용

> 본인 인증 API 구현했습니다
1. 본인 인증 메시지 전송 요청
<img width="771" height="649" alt="Screenshot 2025-10-10 at 14 13 39" src="https://github.com/user-attachments/assets/7e2c64c6-2284-4a80-a498-9a8a2c29b365" />

2. 메시지 수령 후 인증 코드 입력
<img width="824" height="595" alt="Screenshot 2025-10-10 at 14 13 11" src="https://github.com/user-attachments/assets/f2bfcb4c-7e04-463b-9063-191424e57c47" />
<img width="741" height="626" alt="Screenshot 2025-10-10 at 14 01 58" src="https://github.com/user-attachments/assets/10e3ba18-74b8-40af-a7fc-1b5376fb8f53" />
3. 인증 코드 검사
<img width="643" height="619" alt="Screenshot 2025-10-10 at 14 01 56" src="https://github.com/user-attachments/assets/93645dfc-a7a6-446c-920c-597d50956022" />
